### PR TITLE
Add initial wear OS component

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -11,6 +11,7 @@ assignees: ''
 - Make sure you run the latest version of the Android app
 - Make sure you run the latest version of Home Assistant
 - Make sure to check the Companion docs for troubleshooting and configuration: https://companion.home-assistant.io/
+- Make sure the bug you found is not already reported, we love to put work in bugfixes instead of closing duplicate bug reports
   DO NOT DELETE ANY TEXT from this template! All requested information is important.
 -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!-- READ THIS FIRST:
-- Make sure you've checked existing feature requests to make sure you aren't opening a duplicate. If you do open a duplicate issue because you didn't check existing requests, we will close your issue and laugh at you privately.
+- Make sure you've checked existing feature requests to make sure you aren't opening a duplicate. If you do open a duplicate issue because you didn't check existing requests, we will have some work for nothing. Putting this work into more features (maybe even yours!) just feels better.
   DO NOT DELETE ANY TEXT from this template! All requested information is important.
 -->
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.sensors.SensorReceiver
+import io.homeassistant.companion.android.widgets.button.ButtonWidget
 import io.homeassistant.companion.android.widgets.entity.EntityWidget
 import io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidget
 import io.homeassistant.companion.android.widgets.template.TemplateWidget
@@ -116,9 +117,15 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
         }
 
         // Update widgets when the screen turns on, updates are skipped if widgets were not added
+        val buttonWidget = ButtonWidget()
         val entityWidget = EntityWidget()
         val mediaPlayerWidget = MediaPlayerControlsWidget()
         val templateWidget = TemplateWidget()
+
+        registerReceiver(
+            buttonWidget,
+            IntentFilter(Intent.ACTION_SCREEN_ON)
+        )
 
         registerReceiver(
             entityWidget,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -249,11 +249,10 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
     override fun onDisplayPreferenceDialog(preference: Preference) {
         if (preference is SsidPreference) {
-            lateinit var permissionsToCheck: Array<String>
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                permissionsToCheck = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                permissionsToCheck = arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+            val permissionsToCheck: Array<String> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            } else {
+                arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
             }
 
             val fineLocation = DisabledLocationHandler.containsLocationPermission(permissionsToCheck, true)

--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
@@ -53,8 +53,10 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
             if (isGroupSummary && groupNotifications.size == 1 ||
                 !isGroupSummary && groupNotifications.size == 2) {
                 val group = groupNotifications[0].notification.group
-                val groupId = group.hashCode()
-                this.cancel(group, groupId)
+                if (group != null) {
+                    val groupId = group.hashCode()
+                    this.cancel(group, groupId)
+                }
                 return true
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -72,6 +72,29 @@ class ButtonWidget : AppWidgetProvider() {
         }
     }
 
+    private fun updateAllWidgets(
+        context: Context,
+        buttonWidgetEntityList: Array<ButtonWidgetEntity>?
+    ) {
+        if (buttonWidgetEntityList != null) {
+            Log.d(TAG, "Updating all widgets")
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            for (item in buttonWidgetEntityList) {
+                val views = getWidgetRemoteViews(context, item.id)
+
+                views.setViewVisibility(R.id.widgetProgressBar, View.INVISIBLE)
+                views.setViewVisibility(R.id.widgetImageButtonLayout, View.VISIBLE)
+                views.setViewVisibility(R.id.widgetLabelLayout, View.VISIBLE)
+                views.setInt(
+                    R.id.widgetLayout,
+                    "setBackgroundResource",
+                    R.drawable.widget_button_background
+                )
+                appWidgetManager.updateAppWidget(item.id, views)
+            }
+        }
+    }
+
     override fun onDeleted(context: Context, appWidgetIds: IntArray) {
         buttonWidgetDao = AppDatabase.getInstance(context).buttonWidgetDao()
         // When the user deletes the widget, delete the preference associated with it.
@@ -101,11 +124,13 @@ class ButtonWidget : AppWidgetProvider() {
         ensureInjected(context)
 
         buttonWidgetDao = AppDatabase.getInstance(context).buttonWidgetDao()
+        val buttonWidgetList = buttonWidgetDao.getAll()
 
         super.onReceive(context, intent)
         when (action) {
             CALL_SERVICE -> callConfiguredService(context, appWidgetId)
             RECEIVE_DATA -> saveServiceCallConfiguration(context, intent.extras, appWidgetId)
+            Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, buttonWidgetList)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -211,7 +211,9 @@ class ButtonWidget : AppWidgetProvider() {
                         }
                     }
 
+                    Log.d(TAG, "Sending service call to Home Assistant")
                     integrationUseCase.callService(domain, service, serviceDataMap)
+                    Log.d(TAG, "Service call sent successfully")
 
                     // If service call does not throw an exception, send positive feedback
                     feedbackColor = R.drawable.widget_button_background_green

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,7 +1,7 @@
 object Config {
 
     object Plugin {
-        const val android = "com.android.tools.build:gradle:4.1.0"
+        const val android = "com.android.tools.build:gradle:4.1.1"
         const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Dependency.Kotlin.version}"
         const val google = "com.google.gms:google-services:4.3.4"
         const val appDistribution = "com.google.firebase:firebase-appdistribution-gradle:2.0.1"
@@ -17,19 +17,19 @@ object Config {
 
     object Dependency {
         object Kotlin {
-            const val version = "1.4.10"
+            const val version = "1.4.21"
             const val core = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
             const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${version}"
 
-            private const val coroutinesVersion = "1.3.9"
+            private const val coroutinesVersion = "1.4.1"
             const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}"
-            const val coroutinesPlayServices = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.3.9"
+            const val coroutinesPlayServices = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.4.1"
             const val coroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutinesVersion}"
             const val coroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${coroutinesVersion}"
         }
 
         object Google {
-            private const val daggerVersion = "2.29.1"
+            private const val daggerVersion = "2.30.1"
             const val dagger = "com.google.dagger:dagger:${daggerVersion}"
             const val daggerCompiler = "com.google.dagger:dagger-compiler:${daggerVersion}"
 
@@ -94,7 +94,7 @@ object Config {
         }
 
         object Misc {
-            const val sentry = "io.sentry:sentry-android:3.1.0"
+            const val sentry = "io.sentry:sentry-android:3.2.0"
             const val jackson = "com.fasterxml.jackson.module:jackson-module-kotlin:2.11.3"
             const val blurView = "com.eightbitlab:blurview:1.6.3"
             const val iconDialog = "com.maltaisn:icondialog:3.3.0"

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
@@ -48,6 +48,7 @@ class HomeAssistantRetrofit @Inject constructor(urlRepository: UrlRepository) {
                         it.proceed(it.request())
                     }
                 }
+                .callTimeout(30L, TimeUnit.SECONDS)
                 .readTimeout(30L, TimeUnit.SECONDS)
                 .build()
         )

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
@@ -7,6 +7,6 @@ class WifiHelperImpl @Inject constructor(
     private val wifiManager: WifiManager
 ) : WifiHelper {
     override fun getWifiSsid(): String {
-        return wifiManager.connectionInfo.ssid
+        return wifiManager.connectionInfo?.ssid.toString()
     }
 }


### PR DESCRIPTION
## Summary
Initial basic implementation of wear OS. Only includes activity with icon and text.

## Screenshots
![image](https://user-images.githubusercontent.com/34075651/102887116-9c97c380-4456-11eb-9d65-b70ecf2dd1ea.png)


## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Future work:
- authentication (shared data with android app)
- initial sensor implementation
- reading states
- updating states